### PR TITLE
add health check by actuator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <!-- health check -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
 
         <!-- Keycloak  -->
         <dependency>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,3 +22,5 @@ logging.level.org.keycloak=TRACE
 logging.level.org.apache.http=WARN
 spring.main.banner-mode=OFF
 spring.freemarker.checkTemplateLocation=false
+# actuator port
+management.server.port=8081


### PR DESCRIPTION
Adds a health endpoint. Uses the acutator-dependency, the health check is available at  <HOST>:<MANAGEMENT_PORT>/acutator/health 